### PR TITLE
Adding fixes to X509 cert parsing

### DIFF
--- a/_posts/2013-10-13-certificate-parsing-with-openssl.md
+++ b/_posts/2013-10-13-certificate-parsing-with-openssl.md
@@ -342,8 +342,11 @@ Parsing the public key on a certificate is type-specific. Here, we provide infor
 	}
 	
 	const char* sslbuf = OBJ_nid2ln(pubkey_algonid);
-	assert(strlen(sslbuf) < PUBKEY_ALGO_LEN);
-	strncpy(buf, sslbuf, PUBKEY_ALGO_LEN);
+	if (strlen(sslbuf) > PUBKEY_ALGO_LEN) {
+		fprintf(stderr, "public key algorithm name longer than allocated buffer.\n");
+		return EXIT_FAILURE;
+	}
+	strncpy(pubkey_algoname, sslbuf, PUBKEY_ALGO_LEN);
 	
 	if (pubkey_algonid == NID_rsaEncryption || pubkey_algonid == NID_dsa) {
 		

--- a/_posts/2013-10-13-certificate-parsing-with-openssl.md
+++ b/_posts/2013-10-13-certificate-parsing-with-openssl.md
@@ -398,6 +398,10 @@ Parsing the public key on a certificate is type-specific. Here, we provide infor
 		
 		EVP_PKEY_free(pkey);
 	}
+	else {
+		fprintf(stderr, "unable to parse pub key NID %d", pubkey_algonid);
+		return EXIT_FAILURE;
+	}
 	
 
 {% endhighlight %}

--- a/_posts/2013-10-13-certificate-parsing-with-openssl.md
+++ b/_posts/2013-10-13-certificate-parsing-with-openssl.md
@@ -212,7 +212,7 @@ We can calculate the SHA-1 fingerprint (or any other fingerprint) with the follo
 
 {% highlight cpp %}
 
-	#define SHA1LEN 20
+	#define SHA_DIGEST_LEN 20
 	char buf[SHA1LEN];
 	
 	const EVP_MD *digest = EVP_sha1();

--- a/_posts/2013-10-13-certificate-parsing-with-openssl.md
+++ b/_posts/2013-10-13-certificate-parsing-with-openssl.md
@@ -308,6 +308,7 @@ This can be translated into a string representation (either short name or long d
 
 {% highlight cpp %}
 
+	#define SIG_ALGO_LEN 64
 	char sigalgo_name[SIG_ALGO_LEN+1];
 	
 	const char* sslbuf = OBJ_nid2ln(pkey_nid);

--- a/_posts/2013-10-13-certificate-parsing-with-openssl.md
+++ b/_posts/2013-10-13-certificate-parsing-with-openssl.md
@@ -318,7 +318,7 @@ This can be translated into a string representation (either short name or long d
 		return EXIT_FAILURE;
 	}
 	
-	strncpy(buf, sslbuf, PUBKEY_ALGO_LEN);
+	strncpy(sigalgo_name, sslbuf, SIG_ALGO_LEN);
 
 {% endhighlight %}
 

--- a/_posts/2013-10-13-certificate-parsing-with-openssl.md
+++ b/_posts/2013-10-13-certificate-parsing-with-openssl.md
@@ -331,6 +331,7 @@ Parsing the public key on a certificate is type-specific. Here, we provide infor
 
 {% highlight cpp %}
 
+	#define PUBKEY_ALGO_LEN 64
 	char pubkey_algoname[PUBKEY_ALGO_LEN];
 	
 	int pubkey_algonid = OBJ_obj2nid(cert->cert_info->key->algor->algorithm);

--- a/_posts/2013-10-13-certificate-parsing-with-openssl.md
+++ b/_posts/2013-10-13-certificate-parsing-with-openssl.md
@@ -212,8 +212,7 @@ We can calculate the SHA-1 fingerprint (or any other fingerprint) with the follo
 
 {% highlight cpp %}
 
-	#define SHA_DIGEST_LEN 20
-	char buf[SHA1LEN];
+	char buf[SHA_DIGEST_LENGTH];
 	
 	const EVP_MD *digest = EVP_sha1();
 	unsigned len;

--- a/_posts/2013-10-13-certificate-parsing-with-openssl.md
+++ b/_posts/2013-10-13-certificate-parsing-with-openssl.md
@@ -313,8 +313,8 @@ This can be translated into a string representation (either short name or long d
 	
 	const char* sslbuf = OBJ_nid2ln(pkey_nid);
 	
-	if (strlen(sslbuf) > PUBKEY_ALGO_LEN) {
-		fprintf(stderr, "public key algorithm name longer than allocated buffer.\n");
+	if (strlen(sslbuf) > SIG_ALGO_LEN) {
+		fprintf(stderr, "signature algorithm name longer than allocated buffer.\n");
 		return EXIT_FAILURE;
 	}
 	


### PR DESCRIPTION
A bunch of fixes for things like referencing the wrong variable, wrong error messages, defining constants, etc.